### PR TITLE
Redict to sign in page after sign up

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -12,5 +12,9 @@ module Users
         u.permit(:name, :email, :password, :password_confirmation, :current_password)
       end
     end
+
+    def after_inactive_sign_up_path_for(_resource)
+      new_user_session_path
+    end
   end
 end


### PR DESCRIPTION
Redirect to root then redirect to sign in page after sign up loses the message after sign up. Fixed it.