### PR TITLE
Unload Google Analytics unless the tracking ID is set

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -9,7 +9,7 @@ html
     = stylesheet_link_tag    'https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.10.0/css/bootstrap-select.min.css'
     = javascript_include_tag 'application', 'data-turbolinks-track' => 'reload'
     = javascript_include_tag 'https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.10.0/js/bootstrap-select.min.js'
-    = render 'shared/google_analytics'
+    = render 'shared/google_analytics', tracking_id: Settings.google.analytics.tracking_id
 
   body id="#{controller_name}_#{action_name}"
     = render 'layouts/header'

--- a/app/views/shared/_google_analytics.html.slim
+++ b/app/views/shared/_google_analytics.html.slim
@@ -4,7 +4,7 @@ javascript:
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
   })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-  ga('create', '#{Settings.google.analytics.tracking_id}', 'auto');
+  ga('create', '#{tracking_id}', 'auto');
   //ga('send', 'pageview');
   // For turbolinks
   $(document).on('turbolinks:load', function() {

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -82,4 +82,4 @@ mailgun:
   password: <%= ENV['MAILGUN_PASSWORD'] || 'TBA' %>
 google:
   analytics:
-    tracking_id: <%= ENV['GOOGLE_ANALYTICS_TRACKING_ID'] || 'TBA' %>
+    tracking_id: <%= ENV['GOOGLE_ANALYTICS_TRACKING_ID'] %>


### PR DESCRIPTION
It's not good to send logs with `TBA` tracking ID to GA.