### PR TITLE
Allow placeholder only URL

### DIFF
--- a/app/models/test_step/navigation.rb
+++ b/app/models/test_step/navigation.rb
@@ -2,7 +2,8 @@ module TestStep
   class Navigation < Base
     using Refinements::ReplaceVariables
 
-    validates :url, length: { minimum: 1, maximum: 255 }, url: true, presence: true
+    validates :url, length: { minimum: 1, maximum: 255 }, presence: true
+    validates :url, url: true, unless: -> (ts) { ts.url =~ /\A{[^}]+}\Z/ }
 
     serialized_attribute :url
 


### PR DESCRIPTION
<img width="794" alt="screen shot 2016-05-09 at 3 13 59 pm" src="https://cloud.githubusercontent.com/assets/1162120/15129772/b0faf02c-15f8-11e6-8056-bdf93a5fa346.png">

It's useful if you can use placeholder to replace entire URL.