### PR TITLE
Use pre to show page source contents

### DIFF
--- a/app/models/page_source.rb
+++ b/app/models/page_source.rb
@@ -6,4 +6,8 @@ class PageSource < ApplicationRecord
                              hash_secret: '6d14270fa22e07789913b245b70c1f801f8201e8327a6420ae5dc652bd2ccc5b'
 
   validates :source, attachment_content_type: { content_type: %r{\Atext\/.*\Z} }
+
+  def contents
+    ::Paperclip.io_adapters.for(source).read
+  end
 end

--- a/app/views/test_executions/show.html.slim
+++ b/app/views/test_executions/show.html.slim
@@ -67,7 +67,7 @@ div data-path-done-test-execution-path=done_test_execution_path(@test_execution)
         .panel.panel-default
           .panel-heading
             small.glyphicon.glyphicon-link
-            = t('.test_execution_shares')
+            = " #{t('.test_execution_shares')}"
           table.table
             tr
               th.col-lg-3.col-md-3.col-sm-3.col-xs-3 = TestExecutionShare.human_attribute_name(:name).humanize

--- a/app/views/test_step_executions/show.html.slim
+++ b/app/views/test_step_executions/show.html.slim
@@ -35,4 +35,5 @@ div
         = image_tag @test_step_execution.screenshot.image.url, width: '100%'
     - elsif @test_step_execution.test_step.page_source? && @test_step_execution.page_source.try(:source).present?
       div
-        = link_to PageSource.model_name.human, @test_step_execution.page_source.source.url, target: '_blank'
+        pre.pre-scrollable
+          = @test_step_execution.page_source.contents


### PR DESCRIPTION
Solve #88

<img width="1167" alt="screen shot 2016-05-16 at 1 52 22 pm" src="https://cloud.githubusercontent.com/assets/1162120/15303606/7164ff28-1b6d-11e6-8a67-74c985d4e2dc.png">
