### PR TITLE
Skip URL validation with variables

### DIFF
--- a/app/models/test_step/navigation.rb
+++ b/app/models/test_step/navigation.rb
@@ -3,7 +3,7 @@ module TestStep
     using Refinements::ReplaceVariables
 
     validates :url, length: { minimum: 1, maximum: 255 }, presence: true
-    validates :url, url: true, unless: -> (ts) { ts.url =~ /\A{[^}]+}\Z/ }
+    validates :url, url: true, unless: -> (ts) { ts.url =~ /{[^}]+}/ }
 
     serialized_attribute :url
 

--- a/spec/models/test_step/navigation_spec.rb
+++ b/spec/models/test_step/navigation_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe TestStep::Navigation, type: :model do
       expect(subject).to be_valid
     end
     context 'with only placeholder' do
-      subject(:test_step) { build :navigation_step, url: '{foo}' }
+      subject(:test_step) { build :navigation_step, url: 'http://{foo}//bar' }
       it 'is not valid' do
         expect(subject).to be_valid
       end


### PR DESCRIPTION
Navigation URL needs to be more flexible.

e.g.

`http://{domain}/foo/bar`
`http://example.com/foo?lang={lang}`