### PR TITLE
Test assets precompile in CI

### DIFF
--- a/config/initializers/bower_rails.rb
+++ b/config/initializers/bower_rails.rb
@@ -9,7 +9,7 @@ BowerRails.configure do |bower_rails|
   bower_rails.resolve_before_precompile = true
 
   # Invokes rake bower:clean before precompilation. Defaults to false
-  bower_rails.clean_before_precompile = true
+  # bower_rails.clean_before_precompile = true
 
   # Invokes rake bower:install:deployment instead rake bower:install. Defaults to false
   # bower_rails.use_bower_install_deployment = true


### PR DESCRIPTION
`bower_rails.clean_before_precompile` option caused empty components.