### PR TITLE
Remove workaround for cleardb URL scheme

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: DATABASE_URL=$(echo -n $CLEARDB_DATABASE_URL | sed 's/mysql:/mysql2:/') bundle exec puma -C config/puma.rb
-worker: DATABASE_URL=$(echo -n $CLEARDB_DATABASE_URL | sed 's/mysql:/mysql2:/') bundle exec sidekiq -C config/sidekiq.yml -c 2 -v
+web: bundle exec puma -C config/puma.rb
+worker: bundle exec sidekiq -C config/sidekiq.yml -c 2 -v


### PR DESCRIPTION
Set `DATABASE_URL` by Heroku env.