### PR TITLE
Show recent test executions on test show page

### DIFF
--- a/app/controllers/tests_controller.rb
+++ b/app/controllers/tests_controller.rb
@@ -14,6 +14,7 @@ class TestsController < BaseController
     @user_test = @test.user_tests.with_user(current_user).includes(:user_test_variables).first
     @user_tests = @test.user_tests.eager_load(:user).limit(10)
     @integrations = current_user.user_integrations.limit(10)
+    @test_executions = @test.test_executions.with_user(current_user).eager_load(:test_version).latest.limit(10)
   end
 
   def new

--- a/app/models/test.rb
+++ b/app/models/test.rb
@@ -6,6 +6,7 @@ class Test < ApplicationRecord
   has_many :updating_test_versions, -> { where(id: nil) }, class_name: 'TestVersion', inverse_of: :test
   has_many :accessible_users, through: :user_tests, source: :user
   has_many :user_notification_settings, inverse_of: :test
+  has_many :test_executions, through: :test_versions
 
   acts_as_paranoid
 

--- a/app/views/tests/show.html.slim
+++ b/app/views/tests/show.html.slim
@@ -49,6 +49,36 @@
   .alert.alert-warning
     = t('shared.no_records', target: TestVersion.model_name.human)
 
+- if @test_executions.present?
+  div.panel.panel-default
+    div.panel-heading
+      small.glyphicon.glyphicon-tasks
+      = " #{TestExecution.model_name.human(count: 2).humanize}"
+    table.table
+      tr
+        th = TestVersion.human_attribute_name(:position).humanize
+        th = TestVersion.human_attribute_name(:title).humanize
+        th = TestExecution.human_attribute_name(:id).humanize
+        th = TestExecution.human_attribute_name(:executed_at).humanize
+        th = TestExecution.human_attribute_name(:user).humanize
+        th
+      - @test_executions.each do |te|
+        tr
+          td = link_to te.test_version.position, test_version_position_path(te.test_version)
+          td = link_to te.test_version.title, test_version_position_path(te.test_version)
+          td = link_to te.to_param, test_execution_path(te)
+          td = link_to test_execution_path(te) do
+            time datetime=te.executed_at.iso8601 data-timeago='' = te.executed_at.to_s
+          td
+            = gravatar_image_tag(te.user.email, alt: te.user.name, gravatar: { size: 20 })
+            |  
+            = te.user.name
+          td
+            = button_to t('shared.buttons.retry'), test_version_position_test_executions_path(te.test_version), class: 'btn btn-xs btn-primary', method: :post, disabled: !te.test_version.executable?
+- else
+  .alert.alert-warning
+    = t('shared.no_records', target: TestExecution.model_name.human)
+
 .row
   .col-lg-6
     - if @user_test.present?


### PR DESCRIPTION
It's useful if we can see the recent test executions on the test show page.